### PR TITLE
chore: update notty to 0.2.3

### DIFF
--- a/asai.opam
+++ b/asai.opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/RedPRL/asai/issues"
 depends: [
   "ocaml"
   "dune" {>= "3.1"}
-  "notty" {>= "0.2"}
+  "notty" {>= "0.2.3"}
   "lsp" {>= "1.12"}
   "eio" {>= "0.2"}
   "eio_main" {>= "0.2"}

--- a/dune-project
+++ b/dune-project
@@ -23,7 +23,7 @@
    ocaml
    dune
    ;; [TODO: Reed M, 08/06/2022] I should conditionally compile this!
-   (notty (>= 0.2))
+   (notty (>= 0.2.3))
    (lsp (>= 1.12))
    (eio (>= 0.2))
    (eio_main (>= 0.2))


### PR DESCRIPTION
# Patch Description

Version `0.2.3` of notty has some breaking changes for the type of `I.string` (annoyingly!!!), which was causing CI to break. This patch updates the lower bound on our `notty` dep, and makes the required fixes for the breaking change.