### PR TITLE
style!: remove the label of the 'code' argument

### DIFF
--- a/examples/stlc/STLC.ml
+++ b/examples/stlc/STLC.ml
@@ -25,10 +25,10 @@ struct
     match Bwd.find_opt (fun (nm', _) -> String.equal nm nm') ctx with
     | Some (_, tp) -> tp
     | None ->
-      Doctor.fatalf ?loc ~code:UnboundVariable "Variable '%s' is not in scope" nm
+      Doctor.fatalf ?loc UnboundVariable "Variable '%s' is not in scope" nm
 
   let expected_connective conn tp =
-    Doctor.fatalf ?loc:(get_loc ()) ~code:TypeError  "Expected a %s, but got %a." conn pp_tp tp
+    Doctor.fatalf ?loc:(get_loc ()) TypeError "Expected a %s, but got %a." conn pp_tp tp
 
   let rec equate expected actual =
     Doctor.tracef "When Equating" @@ fun () ->
@@ -42,7 +42,7 @@ struct
     | Nat, Nat ->
       ()
     | _, _ ->
-      Doctor.fatalf ?loc:(get_loc ()) ~code:TypeError "Expected type %a, but got %a." pp_tp expected pp_tp actual
+      Doctor.fatalf ?loc:(get_loc ()) TypeError "Expected type %a, but got %a." pp_tp expected pp_tp actual
 
   let rec chk (tm : tm) (tp : tp) : unit =
     Doctor.tracef ?loc:tm.loc "When checking against %a" Syntax.pp_tp tp @@ fun () ->
@@ -109,7 +109,7 @@ struct
         mot
       end
     | _ ->
-      Doctor.fatalf ?loc:(get_loc ()) ~code:TypeError "Unable to infer type"
+      Doctor.fatalf ?loc:(get_loc ()) TypeError "Unable to infer type"
 end
 
 module Driver =
@@ -121,10 +121,10 @@ struct
       try Grammar.defn Lex.token lexbuf with
       | Lex.SyntaxError tok ->
         let pos = Span.of_lex_position lexbuf.lex_curr_p in
-        Doctor.fatalf ~loc:(Span.make pos pos) ~code:LexerError "Unrecognized token '%s'" tok
+        Doctor.fatalf ~loc:(Span.make pos pos) LexerError "Unrecognized token '%s'" tok
       | Grammar.Error ->
         let pos = Span.of_lex_position lexbuf.lex_curr_p in
-        Doctor.fatalf ~loc:(Span.make pos pos) ~code:LexerError "Failed to parse"
+        Doctor.fatalf ~loc:(Span.make pos pos) LexerError "Failed to parse"
     in
     Elab.Reader.run ~env:{ctx = Emp ; loc = None} @@ fun () ->
     Elab.chk tm tp

--- a/src/core/Logger.ml
+++ b/src/core/Logger.ml
@@ -12,9 +12,9 @@ struct
   let ktracef = DB.ktracef
   let append_marks = DB.append_marks
   let emit = DE.emit
-  let emitf ?loc ?additional_marks ?severity ~code = DB.kmessagef emit ?loc ?additional_marks ?severity ~code
+  let emitf ?loc ?additional_marks ?severity code = DB.kmessagef emit ?loc ?additional_marks ?severity code
   let fatal = DE.fatal
-  let fatalf ?loc ?additional_marks ?severity ~code = DB.kmessagef fatal ?loc ?additional_marks ?severity ~code
+  let fatalf ?loc ?additional_marks ?severity code = DB.kmessagef fatal ?loc ?additional_marks ?severity code
   let run ?init_backtrace ~emit ~fatal f = DB.run ?init:init_backtrace @@ fun () -> DE.run ~emit ~fatal f
   let bridge m run f = run ?init_backtrace:(Some (backtrace ())) ~emit:(fun d -> emit (m d)) ~fatal:(fun d -> fatal (m d)) f
   let try_with = DE.try_with

--- a/src/core/LoggerSigs.ml
+++ b/src/core/LoggerSigs.ml
@@ -2,11 +2,11 @@ module type S =
 sig
   module Code : Code.S
 
-  (** [messagef ~loc ~additional_marks ~code format ...] constructs a diagnostic along with the backtrace frames recorded via [tracef]. *)
-  val messagef : ?loc:Span.t -> ?additional_marks:Span.t list -> ?severity:Severity.t -> code:Code.t -> ('a, Format.formatter, unit, Code.t Diagnostic.t) format4 -> 'a
+  (** [messagef ~loc ~additional_marks code format ...] constructs a diagnostic along with the backtrace frames recorded via [tracef]. *)
+  val messagef : ?loc:Span.t -> ?additional_marks:Span.t list -> ?severity:Severity.t -> Code.t -> ('a, Format.formatter, unit, Code.t Diagnostic.t) format4 -> 'a
 
-  (** [kmessagef kont ~loc ~additional_marks ~code format ...] constructs a diagnostic and then apply [kont] to the resulting diagnostic. *)
-  val kmessagef : (Code.t Diagnostic.t -> 'b) -> ?loc:Span.t -> ?additional_marks:Span.t list -> ?severity:Severity.t -> code:Code.t -> ('a, Format.formatter, unit, 'b) format4 -> 'a
+  (** [kmessagef kont ~loc ~additional_marks code format ...] constructs a diagnostic and then apply [kont] to the resulting diagnostic. *)
+  val kmessagef : (Code.t Diagnostic.t -> 'b) -> ?loc:Span.t -> ?additional_marks:Span.t list -> ?severity:Severity.t -> Code.t -> ('a, Format.formatter, unit, 'b) format4 -> 'a
 
   (** [tracef ~loc format ...] record a frame. *)
   val tracef : ?loc:Span.t -> ('a, Format.formatter, unit, (unit -> 'b) -> 'b) format4 -> 'a
@@ -21,14 +21,14 @@ sig
   (** Emit a diagnostic and continue the computation. *)
   val emit : Code.t Diagnostic.t -> unit
 
-  (** [emitf ~loc ~additional_marks ~code format ...] constructs and emits a diagnostic. *)
-  val emitf : ?loc:Span.t -> ?additional_marks:Span.t list -> ?severity:Severity.t -> code:Code.t -> ('a, Format.formatter, unit, unit) format4 -> 'a
+  (** [emitf ~loc ~additional_marks code format ...] constructs and emits a diagnostic. *)
+  val emitf : ?loc:Span.t -> ?additional_marks:Span.t list -> ?severity:Severity.t -> Code.t -> ('a, Format.formatter, unit, unit) format4 -> 'a
 
   (** Emit a diagnostic and abort the computation. *)
   val fatal: Code.t Diagnostic.t -> 'a
 
-  (** [fatalf ~loc ~additional_marks ~code format ...] constructs a diagnostic and abort the current computation. *)
-  val fatalf : ?loc:Span.t -> ?additional_marks:Span.t list -> ?severity:Severity.t -> code:Code.t -> ('a, Format.formatter, unit, 'b) format4 -> 'a
+  (** [fatalf ~loc ~additional_marks code format ...] constructs a diagnostic and abort the current computation. *)
+  val fatalf : ?loc:Span.t -> ?additional_marks:Span.t list -> ?severity:Severity.t -> Code.t -> ('a, Format.formatter, unit, 'b) format4 -> 'a
 
   (** [run ~emit ~fatal f] runs the thunk [f], using [emit] to handle emitted diagnostics before continuing
       the computation, and [fatal] to handle diagnostics after aborting the computation. *)

--- a/src/core/logger/DiagnosticBuilder.ml
+++ b/src/core/logger/DiagnosticBuilder.ml
@@ -10,7 +10,7 @@ struct
 
   let backtrace = Traces.read
 
-  let kmessagef k ?loc ?(additional_marks=[]) ?severity ~code =
+  let kmessagef k ?loc ?(additional_marks=[]) ?severity code =
     Format.kdprintf @@ fun message -> k @@
     Diagnostic.{
       code;
@@ -20,8 +20,8 @@ struct
       backtrace = Traces.read ();
     }
 
-  let messagef ?loc ?additional_marks ?severity ~code =
-    kmessagef Fun.id ?loc ?additional_marks ?severity ~code
+  let messagef ?loc ?additional_marks ?severity code =
+    kmessagef Fun.id ?loc ?additional_marks ?severity code
 
   let append_marks d marks =
     Diagnostic.{ d with additional_marks = d.additional_marks @ marks }

--- a/src/core/logger/DiagnosticBuilderSigs.ml
+++ b/src/core/logger/DiagnosticBuilderSigs.ml
@@ -3,8 +3,8 @@ sig
   module Code : Code.S
 
   val backtrace : unit -> Diagnostic.message Span.located Bwd.bwd
-  val messagef : ?loc:Span.t -> ?additional_marks:Span.t list -> ?severity:Severity.t -> code:Code.t -> ('a, Format.formatter, unit, Code.t Diagnostic.t) format4 -> 'a
-  val kmessagef : (Code.t Diagnostic.t -> 'b) -> ?loc:Span.t -> ?additional_marks:Span.t list -> ?severity:Severity.t -> code:Code.t -> ('a, Format.formatter, unit, 'b) format4 -> 'a
+  val messagef : ?loc:Span.t -> ?additional_marks:Span.t list -> ?severity:Severity.t -> Code.t -> ('a, Format.formatter, unit, Code.t Diagnostic.t) format4 -> 'a
+  val kmessagef : (Code.t Diagnostic.t -> 'b) -> ?loc:Span.t -> ?additional_marks:Span.t list -> ?severity:Severity.t -> Code.t -> ('a, Format.formatter, unit, 'b) format4 -> 'a
   val tracef : ?loc:Span.t -> ('a, Format.formatter, unit, (unit -> 'b) -> 'b) format4 -> 'a
   val ktracef : ('a -> unit -> 'b) -> ?loc:Span.t -> ('c, Format.formatter, unit, 'a -> 'b) format4 -> 'c
   val append_marks : Code.t Diagnostic.t -> Span.t list -> Code.t Diagnostic.t


### PR DESCRIPTION
I think we should remove the `code` label from the Dream API. The type will make sure the order is correct, and it is never the case that the message will be ahead of the code. In other word, the order is fixed in practice and is also obvious from the type.