### PR TITLE
feat: add map_text and Logger.map_diagnostic

### DIFF
--- a/docs/quickstart.mld
+++ b/docs/quickstart.mld
@@ -149,6 +149,41 @@ Logger.emit ~loc:real_loc "Wow!" (* using [real_loc] instead  *)
 (* ... *)
 ]}
 
+{1 Wrapping Errors}
+
+It is common to wrap an error message to give a more intuitive explanation. For example, when using an I/O library to read a configuration file, the I/O library might send out a fatal message saying:
+{v
+File '/path/config.json' does not exist
+v}
+We would like to turn it into a more readable message such as
+{v
+Failed to load settings:
+  File '/path/config.json' does not exist
+v}
+Arguably, this can be achieved via the backtrace API mentioned before:
+{v
+When loading settings...
+File '/path/config.json' does not exist
+v}
+by writing
+{[
+Logger.trace "When loading settings..." @@ fun () -> ...
+]}
+However, if you agree with us that the wrapped error message reads better, do the following instead:
+{[
+Logger.map_text
+  (fun t -> Asai.Diagnostic.textf
+    "@[<2>Failed to load settings:@ @[%t@]@]"
+    t)
+  @@ fun () ->
+(* using the I/O library *)
+]}
+The {{!val:Asai.Logger.S.map_text}map_text} will map the {{!type:Asai.Diagnostic.text}text} in a diagnostic. The {{!val:Asai.Diagnostic.textf}Diagnostic.textf} constructs a new text using fancy format strings as {{!val:Asai.Logger.S.emitf}emitf} and {{!val:Asai.Logger.S.fatalf}fatalf} do. The [%t] is the OCaml conversion specification to format a {{!type:Asai.Diagnostic.text}text}. Putting all these together, we prefix the text in the diagnostic with ["Failed to load settings:"]. The above code can also be written in a more concise style:
+{[
+Logger.map_text (Asai.Diagnostic.textf "@[<2>Failed to load settings:@ @[%t@]@]") @@ fun () ->
+(* using the I/O library *)
+]}
+
 {1 Use a Library that Uses asai}
 
 Suppose you wanted to use a cool OCaml library which is also using asai (which is probably why it is cool), how should you display the messages from the library as if they are yours? Let's assume the library exposes a module [CoolLibrary], and the library authors also followed this tutorial to create a module called [CoolLibrary.Logger]. You want to painlessly incorporate the library.
@@ -212,15 +247,9 @@ let lift_cool f = adopt embed_cool CoolLibrary.Logger.run f
 
 {1 Treat All Messages as Errors}
 
-🚧 {i Note: we might come up with a new, cooler API to simplify this section.}
-
 If you want to turn everything into an error, add the following lines to the end of your [Logger.ml]:
 {[
-let all_as_errors f =
-  try_with
-    ~emit:(fun d -> emit_diagnostic {d with severity = Error})
-    ~fatal:(fun d -> fatal_diagnostic {d with severity = Error})
-    f
+let all_as_errors f = map (fun d -> {d with severity = Error}) f
 ]}
 And then use [Logger.all_as_errors] to turn all messages into errors:
 {[
@@ -228,15 +257,11 @@ Logger.all_as_errors @@ fun () -> (* any message sent here will be an error *)
 ]}
 {b Note that turning a message into an error does not abort the computation.} [all_as_errors] only makes the message look scarier and it will not affect the control flow. If you wish to also abort the program the moment {i any} message is sent, replace {{!val:Asai.Logger.S.emit_diagnostic}emit_diagnostic} with {{!val:Asai.Logger.S.fatal_diagnostic}fatal_diagnostic}:
 {[
-let abort_at_any f =
-  try_with
-    ~emit:(fun d -> fatal_diagnostic {d with severity = Error})
-    ~fatal:(fun d -> fatal_diagnostic {d with severity = Error})
-    f
+let abort_at_any f = map fatal_diagnostic f
 ]}
-Within [abort_at_any], every message will become a {i fatal} error:
+Within [abort_at_any], every message will become {i fatal}:
 {[
-Logger.abort_at_any @@ fun () -> (* any message will be an error AND abort the program *)
+Logger.abort_at_any @@ fun () -> (* any message will abort the program *)
 ]}
 
 {1 Recover from Fatal Messages}

--- a/src/Diagnostic.ml
+++ b/src/Diagnostic.ml
@@ -39,6 +39,10 @@ let kmakef ?loc ?backtrace ?additional_messages k severity code =
 let makef ?loc ?backtrace ?additional_messages severity code =
   ktextf @@ of_text ?loc ?backtrace ?additional_messages severity code
 
+let map f d = {d with code = f d.code}
+
+let map_text f d = {d with message = {d.message with value = f d.message.value}}
+
 let string_of_severity =
   function
   | Hint -> "Hint"
@@ -53,5 +57,3 @@ let string_of_text text : string =
   let () = Format.pp_set_geometry fmt ~max_indent:(Int.max_int-1) ~margin:Int.max_int in
   text fmt;
   Buffer.contents buf
-
-let map f d = {d with code = f d.code}

--- a/src/Diagnostic.mli
+++ b/src/Diagnostic.mli
@@ -80,8 +80,19 @@ val of_message : ?backtrace:backtrace -> ?additional_messages:message list -> se
 
 (** {1 Other Helper Functions} *)
 
-(** A convenience function that maps the message code. This is helpful when using {!val:Logger.S.adopt}. *)
+(** A convenience function that maps the message code of a diagnostic. This is helpful when using {!val:Logger.S.adopt}. *)
 val map : ('code1 -> 'code2) -> 'code1 t -> 'code2 t
+
+(** A convenience function that maps the message text of a diagnostic.
+
+    Example:
+    {[
+      let d2 = map_text (textf "@[<2>Pluto is no longer a planet:@ %t@]") d1
+    ]}
+
+    @since 0.2.0
+*)
+val map_text : (text -> text) -> 'a t -> 'a t
 
 (** A convenience function that converts a {!type:severity} into its constructor name. For example, {!constructor:Warning} will be converted into the string ["Warning"]. *)
 val string_of_severity : severity -> string

--- a/src/DiagnosticData.ml
+++ b/src/DiagnosticData.ml
@@ -25,7 +25,13 @@ end
 
     When we render a diagnostic, the layout engine of the rendering backend should be the one making layout choices. Therefore, we cannot pass already formatted strings. Instead, a text is defined to be a function that takes a formatter and uses it to render the content. The following two conditions must be satisfied:
     + {b All string (and character) literals must be encoded using UTF-8.}
-    + {b All string (and character) literals must not contain control characters (such as the newline character [\n]).} It is okay to have break hints (such as [@,] and [@ ]) but not literal control characters. This means you should avoid pre-formatted strings, and if you must use them, use {!val:text} to convert newline characters. Control characters include `U+0000-001F` (C0 controls), `U+007F` (backspace) and `U+0080-009F` (C1 controls). These characters are banned because they would mess up the cursor position. *)
+    + {b All string (and character) literals must not contain control characters (such as the newline character [\n]).} It is okay to have break hints (such as [@,] and [@ ]) but not literal control characters. This means you should avoid pre-formatted strings, and if you must use them, use {!val:text} to convert newline characters. Control characters include `U+0000-001F` (C0 controls), `U+007F` (backspace) and `U+0080-009F` (C1 controls). These characters are banned because they would mess up the cursor position.
+
+    {i Pro-tip:} to format a text in another text, use [%t]:
+    {[
+      let t2 = textf "@[<2>The network doesn't seem to work:@ %t@]" t1
+    ]}
+*)
 type text = Format.formatter -> unit
 
 (** A message is a located {!type:text}. *)

--- a/src/Logger.ml
+++ b/src/Logger.ml
@@ -74,6 +74,14 @@ struct
   let try_with ?(emit=emit_diagnostic) ?(fatal=fatal_diagnostic) f =
     Effect.Deep.match_with f () @@ handler ~emit ~fatal
 
+  let map_diagnostic m f =
+    try_with
+      ~emit:(fun d -> emit_diagnostic (m d))
+      ~fatal:(fun d -> fatal_diagnostic (m d))
+      f
+
+  let map_text m f = map_diagnostic (Diagnostic.map_text m) f
+
   (* Convenience functions *)
 
   let emit ?severity ?loc ?backtrace ?additional_messages code str =

--- a/src/LoggerSigs.ml
+++ b/src/LoggerSigs.ml
@@ -191,6 +191,28 @@ sig
       @param fatal The interceptor of fatal diagnostics. The default value is {!val:fatal_diagnostic}. *)
   val try_with : ?emit:(Code.t Diagnostic.t -> unit) -> ?fatal:(Code.t Diagnostic.t -> 'a) -> (unit -> 'a) -> 'a
 
+  (** [map_diagnostic m f] runs the thunk [f] and applies [m] to any message sent by [f]. It is a convenience function that can be implemented as follows:
+      {[
+        let map_diagnostic m f =
+          try_with
+            ~fatal:(fun d -> fatal_diagnostic (m d))
+            ~emit:(fun d -> emit_diagnostic (m d))
+            f
+      ]}
+
+      @since 0.2.0
+  *)
+  val map_diagnostic : (Code.t Diagnostic.t -> Code.t Diagnostic.t) -> (unit -> 'a) -> 'a
+
+  (** [map_text m f] runs the thunk [f] and applies [m] to any message sent by [f]. It is a convenience function that can be implemented as follows:
+      {[
+        let map_text m f = map_diagnostic (Diagnostic.map_text m) f
+      ]}
+
+      @since 0.2.0
+  *)
+  val map_text : (Diagnostic.text -> Diagnostic.text) -> (unit -> 'a) -> 'a
+
   val register_printer : ([ `Trace | `Emit of Code.t Diagnostic.t | `Fatal of Code.t Diagnostic.t ] -> string option) -> unit
   (** [register_printer p] registers a printer [p] via {!val:Printexc.register_printer} to convert unhandled internal effects and exceptions into strings for the OCaml runtime system to display. Ideally, all internal effects and exceptions should have been handled by {!val:run} and there is no need to use this function, but when it is not the case, this function can be helpful for debugging. The functor {!module:Logger.Make} always registers a simple printer to suggest using {!val:run}, but you can register new ones to override it. The return type of the printer [p] should return [Some s] where [s] is the resulting string, or [None] if it chooses not to convert a particular effect or exception. The registered printers are tried in reverse order until one of them returns [Some s] for some [s]; that is, the last registered printer is tried first. Note that this function is a wrapper of {!val:Printexc.register_printer} and all the registered printers (via this function or {!val:Printexc.register_printer}) are put into the same list.
 


### PR DESCRIPTION
This PR also added the following pro-tip:

> _Pro-tip:_ to format a text in another text, use %t:
> 
> ```ocaml
> let t2 = textf "@[<2>The network doesn't seem to work:@ %t@]" t1
> ```