### PR TITLE
fix(Tty): show severities

### DIFF
--- a/src/DiagnosticData.ml
+++ b/src/DiagnosticData.ml
@@ -17,7 +17,7 @@ sig
   (** The default severity of the code. The severity of a message is about whether the message is an error or a warning, etc. To clarify, it is about how serious the message is to the {i end user,} not whether the program should stop or continue. The severity may be overwritten at the time of issuing a message to the end user. *)
   val default_severity : t -> severity
 
-  (** A concise, ideally Google-able string representation of each message code. Detailed or long descriptions of code should be avoided. For example, [E001] works better than [type-checking error]. The shorter, the better. *)
+  (** A concise, ideally Google-able string representation of each message code. Detailed or long descriptions of code should be avoided. For example, [E001] works better than [type-checking error]. The shorter, the better. It will be assumed that the string representation only uses ASCII printable characters. *)
   val to_string : t -> string
 end
 

--- a/src/tty/Tty.ml
+++ b/src/tty/Tty.ml
@@ -105,6 +105,19 @@ struct
 
 *)
 
+(*
+ ╭
+ │ When checking against (→ ℕ (→ ℕ ℕ))
+ │
+ │ When checking against (→ ℕ ℕ)
+ │
+ │ When checking against ℕ
+ │
+ │ When synthesizing
+ ╯
+ [E002] Variable 'sdaf' is not in scope
+*)
+
   (* helper functions *)
 
   let hcat_with_pad ~pad l =

--- a/src/tty/Tty.ml
+++ b/src/tty/Tty.ml
@@ -61,8 +61,17 @@ struct
     │
   8 │ assert (asai is cool)
     ┷
- [E002] Why am I checking the term (→ ℕ (→ ℕ ℕ))
-        which looks amazing!!!
+ Error[E002]:
+ Why am I checking the term against (→ ℕ (→ ℕ ℕ)),
+ when it looks amazing?
+
+    ╒══ examples/stlc/example4.lambda
+    │
+  8 │ assert (asai is cool)
+    ┷
+ Error[E002]:
+ Why am I checking the term against (→ ℕ (→ ℕ ℕ)),
+ when it looks amazing?
 
 *)
 
@@ -100,8 +109,9 @@ struct
     ┯
   8 │ assert (asai is cool)
     ┷
- [E002] Why am I checking the term (→ ℕ (→ ℕ ℕ))
-        which looks amazing!!!
+ Error[E002]:
+ Why am I checking the term (→ ℕ (→ ℕ ℕ))
+ which looks amazing!!
 
 *)
 
@@ -115,7 +125,9 @@ struct
  │
  │ When synthesizing
  ╯
- [E002] Variable 'sdaf' is not in scope
+ Error[E002]:
+ Variable 'sdaf' is not in scope
+
 *)
 
   (* helper functions *)
@@ -238,10 +250,13 @@ struct
   (* message *)
   let render_text ~param ~show_code text =
     let attr = message_style param.severity in
-    hcat_with_pad ~pad:1 @@ List.concat
-      [ if show_code then [ I.strf ~attr "[%s]" (Code.to_string param.code) ] else []
-      ; [ I.strf ~attr "%t" text ]
-      ]
+    I.pad ~l:1 begin
+      (if show_code
+       then I.strf ~attr "%s[%s]:" (Diagnostic.string_of_severity param.severity) (Code.to_string param.code)
+       else I.empty)
+      <->
+      I.strf ~attr "%t" text
+    end
 
   let render_message ~param ~show_code explication text =
     render_explication ~param explication
@@ -280,6 +295,8 @@ struct
     (if param.show_backtrace then display_backtrace ~param backtrace else I.empty)
     <->
     display_message ~param ~show_code:true message ~additional_messages
+    <->
+    I.void 0 1 (* new line *)
 
   let display ?(output=Stdlib.stdout) ?(show_backtrace = false) ?(line_breaking=`Traditional) ?(block_splitting_threshold=5) ?(tab_size=8)
       Diagnostic.{severity; code; message; backtrace; additional_messages} =

--- a/src/tty/Tty.ml
+++ b/src/tty/Tty.ml
@@ -43,7 +43,7 @@ struct
  │ 21 │ noooooooooooooooooo
  │    ┷
  │ When blah blah blah
- ╰
+ ╯
     ╒══ examples/stlc/example.lambda
     │
   1 │ (check (λ ä (λ 123
@@ -85,7 +85,7 @@ struct
  │ 21 │ noooooooooooooooooo
  │    ┷
  │ When blah blah blah
- ╰
+ ╯
     ┯
   1 │ (check (λ ä (λ 123
   2 │   sdaf)) (→ ℕ (→ ℕ ℕ)))
@@ -259,7 +259,7 @@ struct
     I.vcat
       [ I.string indentation_style " ╭"
       ; I.tabulate 1 (I.height backtrace) (fun _ _ -> I.string indentation_style " │") <|> backtrace
-      ; I.string indentation_style " ╰"
+      ; I.string indentation_style " ╯"
       ]
 
   let display_diagnostic ~param ~message ~backtrace ~additional_messages =

--- a/src/tty/Tty.ml
+++ b/src/tty/Tty.ml
@@ -112,19 +112,22 @@ struct
 
   (* styles *)
 
+  let message_style (severity : Diagnostic.severity) =
+    let open A in
+    match severity with
+    | Hint -> fg blue
+    | Info -> fg green
+    | Warning -> fg yellow
+    | Error -> fg red
+    | Bug -> bg red ++ fg black
+
   let highlight_style (severity : Diagnostic.severity) (style : Style.t) =
     let open A in
     match style with
     | None -> empty
     | Additional -> st underline
     | HighlightedPrimary ->
-      st underline ++
-      match severity with
-      | Hint -> fg blue
-      | Info -> fg green
-      | Warning -> fg yellow
-      | Error -> fg red
-      | Bug -> bg red ++ fg black
+      st underline ++ message_style severity
 
   let fringe_style = A.fg @@ A.gray 8
 
@@ -221,9 +224,10 @@ struct
 
   (* message *)
   let render_text ~param ~show_code text =
+    let attr = message_style param.severity in
     hcat_with_pad ~pad:1 @@ List.concat
-      [ if show_code then [ I.strf "[%s]" (Code.to_string param.code) ] else []
-      ; [ I.strf "%t" text ]
+      [ if show_code then [ I.strf ~attr "[%s]" (Code.to_string param.code) ] else []
+      ; [ I.strf ~attr "%t" text ]
       ]
 
   let render_message ~param ~show_code explication text =

--- a/src/tty/Tty.mli
+++ b/src/tty/Tty.mli
@@ -4,21 +4,7 @@
 
 (** {1 Display} *)
 
-(** This module provides functions to display or interact with diagnostics in UNIX terminals. A message will look like this:
-
-    {v
-    ╒══ examples/stlc/example.lambda
-    │
-  1 │ (check (λ ä (λ 123
-  2 │   sdaf)) (→ ℕ (→ ℕ ℕ)))
-    ┊
- 20 │ ahhhhhhhhhhhhhhhhhh
- 21 │ noooooooooooooooooo
-    ┷
- [E002] Why am I checking the term (→ ℕ (→ ℕ ℕ)),
-        which looks amazing?
-    v}
-*)
+(** This module provides functions to display or interact with diagnostics in UNIX terminals. *)
 module Make (Code : Diagnostic.Code) : sig
 
   (** [display d] prints the diagnostic [d] to the standard output, using terminal control characters for formatting. A message will look like this:
@@ -41,7 +27,8 @@ module Make (Code : Diagnostic.Code) : sig
     │
   8 │ assert (asai is cool)
     ┷
- [E002] Why am I checking the term (→ ℕ (→ ℕ ℕ))?
+ Error [E002]
+ Why am I checking the term against (→ ℕ (→ ℕ ℕ))?
       v}
 
       @param output The output channel, such as {!val:stdout} and {!val:stderr}. By default, it is {!val:stdout}, the standard output.


### PR DESCRIPTION
So this PR plans to
- [x] Color all the messages, including the ones in the backtraces.
- [x] Show severity as text _somewhere_ and close #85.

(I'm not sure if it's a good idea to also color messages in the backtrace... :thinking:)