### PR TITLE
refactor!: name changes

### DIFF
--- a/examples/adopt/app/App.ml
+++ b/examples/adopt/app/App.ml
@@ -1,7 +1,7 @@
 let lift_syslib f =
-  Reporter.adopt (Asai.Diagnostic.map (fun c -> Reporter.Code.Syslib c)) Syslib.Reporter.run f
+  Reporter.adopt (Asai.Diagnostic.map (fun c -> Reporter.Message.Syslib c)) Syslib.Reporter.run f
 
-module Term = Asai.Tty.Make (Reporter.Code)
+module Term = Asai.Tty.Make(Reporter.Message)
 
 let () =
   Reporter.run ~emit:Term.interactive_trace ~fatal:(Term.display ~show_backtrace:true) @@ fun () ->

--- a/examples/adopt/app/Reporter.ml
+++ b/examples/adopt/app/Reporter.ml
@@ -1,23 +1,23 @@
-module Code =
+module Message =
 struct
   type t =
-    | Syslib of Syslib.Reporter.Code.t
+    | Syslib of Syslib.Reporter.Message.t
     | UserError
 
   let default_severity : t -> Asai.Diagnostic.severity =
     function
     | _ -> Warning
 
-  let to_string : t -> string = function
-    | Syslib c -> Syslib.Reporter.Code.to_string c
+  let short_code : t -> string = function
+    | Syslib c -> Syslib.Reporter.Message.short_code c
     | UserError -> "A000"
 
   let syslib c = Syslib c
 end
 
-include Asai.Reporter.Make(Code)
+include Asai.Reporter.Make(Message)
 
-let lift_syslib f = adopt (Asai.Diagnostic.map Code.syslib) Syslib.Reporter.run f
+let lift_syslib f = adopt (Asai.Diagnostic.map Message.syslib) Syslib.Reporter.run f
 
 let all_as_errors f =
   try_with

--- a/examples/adopt/lib/Reporter.ml
+++ b/examples/adopt/lib/Reporter.ml
@@ -1,4 +1,4 @@
-module Code =
+module Message =
 struct
   type t = FileError | ChiError | EmojiError
 
@@ -6,11 +6,11 @@ struct
     function
     | _ -> Error
 
-  let to_string =
+  let short_code =
     function
     | FileError -> "C000"
     | ChiError -> "C001"
     | EmojiError -> "C002"
 end
 
-include Asai.Reporter.Make(Code)
+include Asai.Reporter.Make(Message)

--- a/examples/stlc/Checker.ml
+++ b/examples/stlc/Checker.ml
@@ -1,9 +1,9 @@
 open Bwd
 open Syntax
 
-module Terminal = Asai.Tty.Make(Reporter.Code)
-module GitHub = Asai.GitHub.Make(Reporter.Code)
-module Server = Asai.Lsp.Make(Reporter.Code)
+module Terminal = Asai.Tty.Make(Reporter.Message)
+module GitHub = Asai.GitHub.Make(Reporter.Message)
+module Server = Asai.Lsp.Make(Reporter.Message)
 
 module Elab =
 struct
@@ -119,7 +119,7 @@ struct
     Elab.chk tm tp
 
   let load mode filepath =
-    let display : Reporter.Code.t Asai.Diagnostic.t -> unit =
+    let display : Reporter.Message.t Asai.Diagnostic.t -> unit =
       match mode with
       | `Debug -> fun d -> Terminal.display ~show_backtrace:true d
       | `Normal -> fun d -> Terminal.display ~show_backtrace:false d

--- a/examples/stlc/Reporter.ml
+++ b/examples/stlc/Reporter.ml
@@ -1,4 +1,4 @@
-module Code =
+module Message =
 struct
   type t =
     [ `TypeError (* Type checking failed *)
@@ -10,7 +10,7 @@ struct
 
   let default_severity _ = Asai.Diagnostic.Error
 
-  let to_string : t -> string =
+  let short_code : t -> string =
     function
     | `TypeError -> "E001"
     | `UnboundVariable -> "E002"
@@ -19,4 +19,4 @@ struct
     | `ParsingError -> "E005"
 end
 
-include Asai.Reporter.Make(Code)
+include Asai.Reporter.Make(Message)

--- a/src/Diagnostic.ml
+++ b/src/Diagnostic.ml
@@ -12,36 +12,36 @@ let textf = Format.dprintf
 
 let ktextf = Format.kdprintf
 
-let message ?loc s = Span.{ loc; value = text s }
+let loctext ?loc s = Span.{ loc; value = text s }
 
-let kmessagef ?loc k = ktextf @@ fun message -> k Span.{ loc; value = message }
+let kloctextf ?loc k = ktextf @@ fun loctext -> k Span.{ loc; value = loctext }
 
-let messagef ?loc = kmessagef Fun.id ?loc
+let loctextf ?loc = kloctextf Fun.id ?loc
 
-let of_message ?(backtrace=Bwd.Emp) ?(additional_messages=[]) severity code message : _ t =
+let of_loctext ?(backtrace=Bwd.Emp) ?(extra_remarks=[]) severity message explanation : _ t =
   { severity
-  ; code
   ; message
+  ; explanation
   ; backtrace
-  ; additional_messages
+  ; extra_remarks
   }
 
-let of_text ?loc ?backtrace ?additional_messages severity code text : _ t =
-  of_message ?backtrace ?additional_messages severity code {loc; value = text}
+let of_text ?loc ?backtrace ?extra_remarks severity message text : _ t =
+  of_loctext ?backtrace ?extra_remarks severity message {loc; value = text}
 
-let make ?loc ?backtrace ?additional_messages severity code str =
-  of_text ?loc ?backtrace ?additional_messages severity code @@ text str
+let make ?loc ?backtrace ?extra_remarks severity message explanation =
+  of_text ?loc ?backtrace ?extra_remarks severity message @@ text explanation
 
-let kmakef ?loc ?backtrace ?additional_messages k severity code =
+let kmakef ?loc ?backtrace ?extra_remarks k severity message =
   ktextf @@ fun text ->
-  k @@ of_text ?loc ?backtrace ?additional_messages severity code text
+  k @@ of_text ?loc ?backtrace ?extra_remarks severity message text
 
-let makef ?loc ?backtrace ?additional_messages severity code =
-  ktextf @@ of_text ?loc ?backtrace ?additional_messages severity code
+let makef ?loc ?backtrace ?extra_remarks severity message =
+  ktextf @@ of_text ?loc ?backtrace ?extra_remarks severity message
 
-let map f d = {d with code = f d.code}
+let map f d = {d with message = f d.message}
 
-let map_text f d = {d with message = {d.message with value = f d.message.value}}
+let map_text f d = {d with explanation = {d.explanation with value = f d.explanation.value}}
 
 let string_of_severity =
   function

--- a/src/Diagnostic.mli
+++ b/src/Diagnostic.mli
@@ -11,103 +11,103 @@ val text : string -> text
 (** [textf format ...] constructs a text. It is an alias of {!val:Format.dprintf}. Note that there should not be any literal control characters (e.g., literal newline characters). *)
 val textf : ('a, Format.formatter, unit, text) format4 -> 'a
 
-(** [ktextf kont format ...] is [kont (textf code format ...)]. It is an alias of {!val:Format.kdprintf}. *)
+(** [ktextf kont format ...] is [kont (textf format ...)]. It is an alias of {!val:Format.kdprintf}. *)
 val ktextf : (text -> 'b) -> ('a, Format.formatter, unit, 'b) format4 -> 'a
 
-(** [message str] converts the string [str] into a message.
+(** [loctext str] converts the string [str] into a loctext.
 
-    @param loc The location of the message (usually the code) to highlight. *)
-val message : ?loc:Span.t -> string -> message
+    @param loc The location of the loctext (usually the code) to highlight. *)
+val loctext : ?loc:Span.t -> string -> loctext
 
-(** [messagef format ...] constructs a message. Note that there should not be any literal control characters (e.g., literal newline characters).
+(** [loctextf format ...] constructs a loctext. Note that there should not be any literal control characters (e.g., literal newline characters).
 
-    @param loc The location of the message (usually the code) to highlight.
+    @param loc The location of the loctext (usually the code) to highlight.
 *)
-val messagef : ?loc:Span.t -> ('a, Format.formatter, unit, message) format4 -> 'a
+val loctextf : ?loc:Span.t -> ('a, Format.formatter, unit, loctext) format4 -> 'a
 
-(** [kmessagef kont format ...] is [kont (messagef code format ...)].
+(** [kloctextf kont format ...] is [kont (loctextf format ...)].
 
-    @param loc The location of the message (usually the code) to highlight.
+    @param loc The location of the loctext (usually the code) to highlight.
 *)
-val kmessagef : ?loc:Span.t -> (message -> 'b) -> ('a, Format.formatter, unit, 'b) format4 -> 'a
+val kloctextf : ?loc:Span.t -> (loctext -> 'b) -> ('a, Format.formatter, unit, 'b) format4 -> 'a
 
 (** {1 Constructing Diagnostics} *)
 
-(** [make severity code str] constructs a diagnostic with the message [str].
+(** [of_text severity message text] constructs a diagnostic from a {!type:text}.
 
     Example:
     {[
-      make Warning `ChiError "Your Ch'i is critically low"
+      of_text Warning ChiError @@ text "Your Ch'i is critically low"
     ]}
 
     @param backtrace The backtrace (to overwrite the accumulative frames up to this point).
-    @param additional_messages Additional messages that part of the backtrace. For example, they can be bindings shadowed by the current one.
-*)
-val make : ?loc:Span.t -> ?backtrace:backtrace -> ?additional_messages:message list -> severity -> 'code -> string -> 'code t
-
-(** [makef severity code format ...] is [make severity code (messagef format ...)]. It formats the message and constructs a diagnostic out of it.
-
-    Example:
-    {[
-      makef Warning `ChiError "Your %s is critically low" "Ch'i"
-    ]}
-
-    @param loc The location of the text (usually the code) to highlight.
-    @param backtrace The backtrace (to overwrite the accumulative frames up to this point).
-    @param additional_messages Additional messages that part of the backtrace. For example, they can be bindings shadowed by the current one.
-*)
-val makef : ?loc:Span.t -> ?backtrace:backtrace -> ?additional_messages:message list -> severity -> 'code -> ('a, Format.formatter, unit, 'code t) format4 -> 'a
-
-(** [kmakef kont severity code format ...] is [kont (makef severity code format ...)].
-
-    @param loc The location of the text (usually the code) to highlight.
-    @param backtrace The backtrace (to overwrite the accumulative frames up to this point).
-    @param additional_messages Additional messages that part of the backtrace. For example, they can be bindings shadowed by the current one.
-*)
-val kmakef : ?loc:Span.t -> ?backtrace:backtrace -> ?additional_messages:message list -> ('code t -> 'b) -> severity -> 'code -> ('a, Format.formatter, unit, 'b) format4 -> 'a
-
-(** [of_message severity code message] constructs a diagnostic from a {!type:message}.
-
-    Example:
-    {[
-      of_message Warning `ChiError @@ message "Your Ch'i is critically low"
-    ]}
-
-    @param backtrace The backtrace (to overwrite the accumulative frames up to this point).
-    @param additional_messages Additional messages that part of the backtrace. For example, they can be bindings shadowed by the current one.
-*)
-val of_message : ?backtrace:backtrace -> ?additional_messages:message list -> severity -> 'code -> message -> 'code t
-
-(** [of_text severity code message] constructs a diagnostic from a {!type:text}.
-
-    Example:
-    {[
-      of_text Warning `ChiError @@ text "Your Ch'i is critically low"
-    ]}
-
-    @param backtrace The backtrace (to overwrite the accumulative frames up to this point).
-    @param additional_messages Additional messages that part of the backtrace. For example, they can be bindings shadowed by the current one.
+    @param extra_remarks Additional remarks that are not part of the backtrace.
 
     @since 0.2.0
 *)
-val of_text : ?loc:Span.t -> ?backtrace:backtrace -> ?additional_messages:message list -> severity -> 'code -> text -> 'code t
+val of_text : ?loc:Span.t -> ?backtrace:backtrace -> ?extra_remarks:loctext list -> severity -> 'message -> text -> 'message t
+
+(** [of_loctext severity message loctext] constructs a diagnostic from a {!type:loctext}.
+
+    Example:
+    {[
+      of_loctext Warning ChiError @@ loctext "Your Ch'i is critically low"
+    ]}
+
+    @param backtrace The backtrace (to overwrite the accumulative frames up to this point).
+    @param extra_remarks Additional remarks that are not part of the backtrace.
+*)
+val of_loctext : ?backtrace:backtrace -> ?extra_remarks:loctext list -> severity -> 'message -> loctext -> 'message t
+
+(** [make severity message loctext] constructs a diagnostic with the [loctext].
+
+    Example:
+    {[
+      make Warning ChiError "Your Ch'i is critically low"
+    ]}
+
+    @param backtrace The backtrace (to overwrite the accumulative frames up to this point).
+    @param extra_remarks Additional remarks that are not part of the backtrace.
+*)
+val make : ?loc:Span.t -> ?backtrace:backtrace -> ?extra_remarks:loctext list -> severity -> 'message -> string -> 'message t
+
+(** [makef severity message format ...] is [of_loctext severity message (loctextf format ...)]. It formats the message and constructs a diagnostic out of it.
+
+    Example:
+    {[
+      makef Warning ChiError "Your %s is critically low" "Ch'i"
+    ]}
+
+    @param loc The location of the text (usually the code) to highlight.
+    @param backtrace The backtrace (to overwrite the accumulative frames up to this point).
+    @param extra_remarks Additional remarks that are not part of the backtrace.
+*)
+val makef : ?loc:Span.t -> ?backtrace:backtrace -> ?extra_remarks:loctext list -> severity -> 'message -> ('a, Format.formatter, unit, 'message t) format4 -> 'a
+
+(** [kmakef kont severity message format ...] is [kont (makef severity message format ...)].
+
+    @param loc The location of the text (usually the code) to highlight.
+    @param backtrace The backtrace (to overwrite the accumulative frames up to this point).
+    @param extra_remarks Additional remarks that are not part of the backtrace.
+*)
+val kmakef : ?loc:Span.t -> ?backtrace:backtrace -> ?extra_remarks:loctext list -> ('message t -> 'b) -> severity -> 'message -> ('a, Format.formatter, unit, 'b) format4 -> 'a
 
 (** {1 Other Helper Functions} *)
 
-(** A convenience function that maps the message code of a diagnostic. This is helpful when using {!val:Reporter.S.adopt}. *)
-val map : ('code1 -> 'code2) -> 'code1 t -> 'code2 t
+(** A convenience function that maps the message of a diagnostic. This is helpful when using {!val:Reporter.S.adopt}. *)
+val map : ('message1 -> 'message2) -> 'message1 t -> 'message2 t
 
-(** A convenience function that maps the message text of a diagnostic. For example, the following code prefixes the message with ["Pluto is no longer a planet"]:
+(** A convenience function that maps the free-form explanation text of a diagnostic. For example, the following code prefixes the explanation with ["Pluto is no longer a planet"]:
     {[
       let d = map_text (textf "@[<2>Pluto is no longer a planet:@ %t@]") detail
     ]}
 
     @since 0.2.0
 *)
-val map_text : (text -> text) -> 'a t -> 'a t
+val map_text : (text -> text) -> 'message t -> 'message t
 
 (** A convenience function that converts a {!type:severity} into its constructor name. For example, {!constructor:Warning} will be converted into the string ["Warning"]. *)
 val string_of_severity : severity -> string
 
-(** A convenience function that converts a {!type:text} into a string by formatting it with the maximum admissible margin. Note that the resulting string may contain control characters and might not be suitable for constructing new instances of {!type:text} or {!type:message}. *)
+(** A convenience function that converts a {!type:text} into a string by formatting it with the maximum admissible margin. Note that the resulting string may contain newline characters. *)
 val string_of_text : text -> string

--- a/src/DiagnosticData.ml
+++ b/src/DiagnosticData.ml
@@ -21,22 +21,22 @@ type severity =
 *)
 type text = Format.formatter -> unit
 
-(** A message is a located {!type:text}. *)
-type message = text Span.located
+(** A loctext is a {!type:text} with location information. "loctext" is a portmanteau of "locate" and "text". *)
+type loctext = text Span.located
 
-(** A backtrace is a (backward) list of messages. *)
-type backtrace = message bwd
+(** A backtrace is a (backward) list of loctexts. *)
+type backtrace = loctext bwd
 
 (** The type of diagnostics. *)
-type 'code t = {
+type 'message t = {
   severity : severity;
   (** Severity of the diagnostic. *)
-  code : 'code;
-  (** The message code. *)
-  message : message;
-  (** The main message. *)
+  message : 'message;
+  (** The (structured) message. *)
+  explanation : loctext;
+  (** The free-form explanation. *)
   backtrace : backtrace;
   (** The backtrace leading to this diagnostic. *)
-  additional_messages : message list;
-  (** Additional messages relevant to the main message that are not part of the backtrace. *)
+  extra_remarks : loctext list;
+  (** Additional remarks that are relevant to the main message but not part of the backtrace. *)
 }

--- a/src/GitHub.mli
+++ b/src/GitHub.mli
@@ -5,7 +5,7 @@
 ]
 
 (** The functor to create a printer for GitHub Actions workflow commands. *)
-module Make (Code : Reporter.Code) : sig
+module Make (Message : Reporter.Message) : sig
   (** Print a diagnostic as a GitHub Actions workflow command. Only the main message will be printed; backtraces and additional messages are ignored.
 
       Example output:
@@ -14,5 +14,5 @@ module Make (Code : Reporter.Code) : sig
       v}
 
       @see <https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions> *)
-  val print : Code.t Diagnostic.t -> unit
+  val print : Message.t Diagnostic.t -> unit
 end

--- a/src/Reporter.mli
+++ b/src/Reporter.mli
@@ -4,4 +4,4 @@
 include module type of ReporterSigs
 
 (** The functor to generate a logger. *)
-module Make (Code : Code) : S with module Code := Code
+module Make (Message : Message) : S with module Message := Message

--- a/src/ReporterSigs.ml
+++ b/src/ReporterSigs.ml
@@ -1,86 +1,86 @@
-(** The signature of message code. An implementer should specify the message code used in their library or application.
+(** The signature of messages. An implementer should specify the message type used in their library or application.
 
     @since 0.2.0 (moved from Diagnostic.Code)
 *)
-module type Code =
+module type Message =
 sig
-  (** The type of all message codes. *)
+  (** The type of all messages. *)
   type t
 
-  (** The default severity of the code. The severity of a message is about whether the message is an error or a warning, etc. To clarify, it is about how serious the message is to the {i end user,} not whether the program should stop or continue. The severity may be overwritten at the time of issuing a message to the end user. *)
+  (** The default severity level of a message. Severity levels classify diagnostics into errors, warnings, etc. It is about how serious the {i end user} should take the diagnostic, not whether the program should stop or continue. The severity may be overwritten at the time of issuing a diagnostic. *)
   val default_severity : t -> Diagnostic.severity
 
-  (** A concise, ideally Google-able string representation of each message code. Detailed or long descriptions of code should be avoided. For example, [E001] works better than [type-checking error]. The shorter, the better. It will be assumed that the string representation only uses ASCII printable characters. *)
-  val to_string : t -> string
+  (** A concise, ideally Google-able string representation of each message. Detailed or long descriptions of code should be avoided. For example, [E001] works better than [type-checking error]. The shorter, the better. It will be assumed that the string representation only uses ASCII printable characters. *)
+  val short_code : t -> string
 end
 
 module type S =
 sig
-  module Code : Code
+  module Message : Message
 
   (** {2 Sending Messages} *)
 
-  (** [emit code str] emits a string and continues the computation.
+  (** [emit message explanation] emits the [explanation] and continues the computation.
 
       Example:
       {[
         Reporter.emit TypeError "This type is extremely unnatural:\nNat"
       ]}
 
-      @param severity The severity (to overwrite the default severity inferred from the message [code]).
+      @param severity The severity (to overwrite the default severity inferred from the [message]).
       @param loc The location of the text (usually the code) to highlight.
       @param backtrace The backtrace (to overwrite the accumulative frames up to this point).
-      @param additional_messages Additional messages that part of the backtrace. For example, they can be bindings shadowed by the current one.
+      @param extra_remarks Additional remarks that are not part of the backtrace.
   *)
-  val emit : ?severity:Diagnostic.severity -> ?loc:Span.t -> ?backtrace:Diagnostic.backtrace -> ?additional_messages:Diagnostic.message list -> Code.t -> string -> unit
+  val emit : ?severity:Diagnostic.severity -> ?loc:Span.t -> ?backtrace:Diagnostic.backtrace -> ?extra_remarks:Diagnostic.loctext list -> Message.t -> string -> unit
 
-  (** [emitf code format ...] formats and emits a message, and then continues the computation. Note that there should not be any literal control characters. See {!type:Diagnostic.text}.
+  (** [emitf message format ...] formats and emits a message, and then continues the computation. Note that there should not be any literal control characters. See {!type:Diagnostic.text}.
 
       Example:
       {[
         Reporter.emitf TypeError "Type %a is too ugly" Syntax.pp tp
       ]}
 
-      @param severity The severity (to overwrite the default severity inferred from the message [code]).
+      @param severity The severity (to overwrite the default severity inferred from the [message]).
       @param loc The location of the text (usually the code) to highlight.
       @param backtrace The backtrace (to overwrite the accumulative frames up to this point).
-      @param additional_messages Additional messages that part of the backtrace. For example, they can be bindings shadowed by the current one.
+      @param extra_remarks Additional remarks that are not part of the backtrace.
   *)
-  val emitf : ?severity:Diagnostic.severity -> ?loc:Span.t -> ?backtrace:Diagnostic.backtrace -> ?additional_messages:Diagnostic.message list -> Code.t -> ('a, Format.formatter, unit, unit) format4 -> 'a
+  val emitf : ?severity:Diagnostic.severity -> ?loc:Span.t -> ?backtrace:Diagnostic.backtrace -> ?extra_remarks:Diagnostic.loctext list -> Message.t -> ('a, Format.formatter, unit, unit) format4 -> 'a
 
   (** Emit a diagnostic and continue the computation. *)
-  val emit_diagnostic : Code.t Diagnostic.t -> unit
+  val emit_diagnostic : Message.t Diagnostic.t -> unit
 
-  (** [fatal code str] aborts the current computation with the string [str].
+  (** [fatal message explanation] aborts the current computation with the [explanation].
 
       Example:
       {[
         Reporter.fatal CatError "Forgot to feed the cat"
       ]}
 
-      @param severity The severity (to overwrite the default severity inferred from the message [code]).
+      @param severity The severity (to overwrite the default severity inferred from the [message]).
       @param loc The location of the text (usually the code) to highlight.
       @param backtrace The backtrace (to overwrite the accumulative frames up to this point).
-      @param additional_messages Additional messages that part of the backtrace. For example, they can be bindings shadowed by the current one.
+      @param extra_remarks Additional remarks that are not part of the backtrace.
   *)
-  val fatal : ?severity:Diagnostic.severity -> ?loc:Span.t -> ?backtrace:Diagnostic.backtrace -> ?additional_messages:Diagnostic.message list -> Code.t -> string -> 'a
+  val fatal : ?severity:Diagnostic.severity -> ?loc:Span.t -> ?backtrace:Diagnostic.backtrace -> ?extra_remarks:Diagnostic.loctext list -> Message.t -> string -> 'a
 
-  (** [fatalf code format ...] constructs a diagnostic and aborts the current computation with the diagnostic. Note that there should not be any literal control characters. See {!type:Diagnostic.text}.
+  (** [fatalf message format ...] constructs a diagnostic and aborts the current computation with the diagnostic. Note that there should not be any literal control characters. See {!type:Diagnostic.text}.
 
       Example:
       {[
         Reporter.fatalf FileError "Failed to write the password %s on the screen" file_path
       ]}
 
-      @param severity The severity (to overwrite the default severity inferred from the message [code]).
+      @param severity The severity (to overwrite the default severity inferred from the [message]).
       @param loc The location of the text (usually the code) to highlight.
       @param backtrace The backtrace (to overwrite the accumulative frames up to this point).
-      @param additional_messages Additional messages that part of the backtrace. For example, they can be bindings shadowed by the current one.
+      @param extra_remarks Additional remarks that are not part of the backtrace.
   *)
-  val fatalf : ?severity:Diagnostic.severity -> ?loc:Span.t -> ?backtrace:Diagnostic.backtrace -> ?additional_messages:Diagnostic.message list -> Code.t -> ('a, Format.formatter, unit, 'b) format4 -> 'a
+  val fatalf : ?severity:Diagnostic.severity -> ?loc:Span.t -> ?backtrace:Diagnostic.backtrace -> ?extra_remarks:Diagnostic.loctext list -> Message.t -> ('a, Format.formatter, unit, 'b) format4 -> 'a
 
   (** Abort the computation with a diagnostic. *)
-  val fatal_diagnostic: Code.t Diagnostic.t -> 'a
+  val fatal_diagnostic: Message.t Diagnostic.t -> 'a
 
   (** {2 Backtraces} *)
 
@@ -103,19 +103,19 @@ sig
   *)
   val trace : ?loc:Span.t -> string -> (unit -> 'a) -> 'a
 
-  (** [tracef format ... f] formats and records a message as a frame in the backtrace, and runs the thunk [f] with the new backtrace. Note that there should not be any literal control characters. See {!type:Diagnostic.text}.
+  (** [tracef format ... f] formats and records a loctext as a frame in the backtrace, and runs the thunk [f] with the new backtrace. Note that there should not be any literal control characters. See {!type:Diagnostic.text}.
 
       @param loc The location of the text (usually the code) to highlight.
   *)
   val tracef : ?loc:Span.t -> ('a, Format.formatter, unit, (unit -> 'b) -> 'b) format4 -> 'a
 
-  (** [trace_text text f] records the message [text] and runs the thunk [f] with the new backtrace.
+  (** [trace_text text f] records the [text] and runs the thunk [f] with the new backtrace.
 
       @param loc The location of the text (usually the code) to highlight. *)
   val trace_text : ?loc:Span.t -> Diagnostic.text -> (unit -> 'a) -> 'a
 
-  (** [trace_message msg f] records the message [msg] and runs the thunk [f] with the new backtrace. *)
-  val trace_message : Diagnostic.message -> (unit -> 'a) -> 'a
+  (** [trace_loctext loctext f] records the [loctext] and runs the thunk [f] with the new backtrace. *)
+  val trace_loctext : Diagnostic.loctext -> (unit -> 'a) -> 'a
 
   (** {2 Locations} *)
 
@@ -132,42 +132,42 @@ sig
 
   (** Functions in this section differ from the ones in {!module:Diagnostic} (for example, {!val:Diagnostic.make}) in that they fill out the current location, the current backtrace, and the severity automatically. (One can still overwrite them with optional arguments.) *)
 
-  (** [diagnostic code str] constructs a diagnostic with the message [str] along with the backtrace frames recorded via {!val:trace}.
+  (** [diagnostic message explanation] constructs a diagnostic with the [explanation] along with the backtrace frames recorded via {!val:trace}.
 
       Example:
       {[
         Reporter.diagnostic SyntaxError "Too many emojis."
       ]}
 
-      @param severity The severity (to overwrite the default severity inferred from the message [code]).
+      @param severity The severity (to overwrite the default severity inferred from the [message]).
       @param loc The location of the text (usually the code) to highlight.
       @param backtrace The backtrace (to overwrite the accumulative frames up to this point).
-      @param additional_messages Additional messages that part of the backtrace. For example, they can be bindings shadowed by the current one.
+      @param extra_remarks Additional remarks that are not part of the backtrace.
   *)
-  val diagnostic : ?severity:Diagnostic.severity -> ?loc:Span.t -> ?backtrace:Diagnostic.backtrace -> ?additional_messages:Diagnostic.message list -> Code.t -> string -> Code.t Diagnostic.t
+  val diagnostic : ?severity:Diagnostic.severity -> ?loc:Span.t -> ?backtrace:Diagnostic.backtrace -> ?extra_remarks:Diagnostic.loctext list -> Message.t -> string -> Message.t Diagnostic.t
 
-  (** [diagnosticf code format ...] constructs a diagnostic along with the backtrace frames recorded via {!val:trace}. Note that there should not be any literal control characters. See {!type:Diagnostic.text}.
+  (** [diagnosticf message format ...] constructs a diagnostic along with the backtrace frames recorded via {!val:trace}. Note that there should not be any literal control characters. See {!type:Diagnostic.text}.
 
       Example:
       {[
         Reporter.diagnosticf TypeError "Term %a does not type check, or does it?" Syntax.pp tm
       ]}
 
-      @param severity The severity (to overwrite the default severity inferred from the message [code]).
+      @param severity The severity (to overwrite the default severity inferred from the [message]).
       @param loc The location of the text (usually the code) to highlight.
       @param backtrace The backtrace (to overwrite the accumulative frames up to this point).
-      @param additional_messages Additional messages that part of the backtrace. For example, they can be bindings shadowed by the current one.
+      @param extra_remarks Additional remarks that are not part of the backtrace.
   *)
-  val diagnosticf : ?severity:Diagnostic.severity -> ?loc:Span.t -> ?backtrace:Diagnostic.backtrace -> ?additional_messages:Diagnostic.message list -> Code.t -> ('a, Format.formatter, unit, Code.t Diagnostic.t) format4 -> 'a
+  val diagnosticf : ?severity:Diagnostic.severity -> ?loc:Span.t -> ?backtrace:Diagnostic.backtrace -> ?extra_remarks:Diagnostic.loctext list -> Message.t -> ('a, Format.formatter, unit, Message.t Diagnostic.t) format4 -> 'a
 
-  (** [kdiagnosticf kont code format ...] is [kont (diagnosticf code format ...)]. Note that there should not be any literal control characters. See {!type:Diagnostic.text}.
+  (** [kdiagnosticf kont message format ...] is [kont (diagnosticf message format ...)]. Note that there should not be any literal control characters. See {!type:Diagnostic.text}.
 
-      @param severity The severity (to overwrite the default severity inferred from the message [code]).
+      @param severity The severity (to overwrite the default severity inferred from the [message]).
       @param loc The location of the text (usually the code) to highlight.
       @param backtrace The backtrace (to overwrite the accumulative frames up to this point).
-      @param additional_messages Additional messages that part of the backtrace. For example, they can be bindings shadowed by the current one.
+      @param extra_remarks Additional remarks that are not part of the backtrace.
   *)
-  val kdiagnosticf : ?severity:Diagnostic.severity -> ?loc:Span.t -> ?backtrace:Diagnostic.backtrace -> ?additional_messages:Diagnostic.message list -> (Code.t Diagnostic.t -> 'b) -> Code.t -> ('a, Format.formatter, unit, 'b) format4 -> 'a
+  val kdiagnosticf : ?severity:Diagnostic.severity -> ?loc:Span.t -> ?backtrace:Diagnostic.backtrace -> ?extra_remarks:Diagnostic.loctext list -> (Message.t Diagnostic.t -> 'b) -> Message.t -> ('a, Format.formatter, unit, 'b) format4 -> 'a
 
   (** {2 Algebraic Effects} *)
 
@@ -176,7 +176,7 @@ sig
       @param init_backtrace The initial backtrace to start with. The default value is the empty backtrace.
       @param emit The handler of non-fatal diagnostics.
       @param fatal The handler of fatal diagnostics. *)
-  val run : ?init_loc:Span.t -> ?init_backtrace:Diagnostic.backtrace -> emit:(Code.t Diagnostic.t -> unit) -> fatal:(Code.t Diagnostic.t -> 'a) -> (unit -> 'a) -> 'a
+  val run : ?init_loc:Span.t -> ?init_backtrace:Diagnostic.backtrace -> emit:(Message.t Diagnostic.t -> unit) -> fatal:(Message.t Diagnostic.t -> 'a) -> (unit -> 'a) -> 'a
 
   (** [adopt m run f] runs the thunk [f] that uses a {i different} [Reporter] instance. It takes the runner [run] from that [Reporter] instance as an argument to handle effects, and will use [m] to transform diagnostics generated by [f] into ones in the current [Reporter] instance. The backtrace within [f] will include the backtrace that leads to [adopt], and the innermost specified location will be carried over, too. The intended use case is to integrate diagnostics from a library into those in the main application.
 
@@ -193,21 +193,21 @@ sig
 
       Here shows the intended usage, where [Lib] is the library to be used in the main application:
       {[
-        module MainReporter = Reporter.Make(Code)
+        module MainReporter = Reporter.Make(Message)
         module LibReporter = Lib.Reporter
 
-        let _ = MainReporter.adopt (Diagnostic.map code_mapper) LibReporter.run @@ fun () -> ...
+        let _ = MainReporter.adopt (Diagnostic.map message_mapper) LibReporter.run @@ fun () -> ...
       ]}
   *)
-  val adopt : ('code Diagnostic.t -> Code.t Diagnostic.t) -> (?init_loc:Span.t -> ?init_backtrace:Diagnostic.backtrace -> emit:('code Diagnostic.t -> unit) -> fatal:('code Diagnostic.t -> 'a) -> (unit -> 'a) -> 'a) -> (unit -> 'a) -> 'a
+  val adopt : ('message Diagnostic.t -> Message.t Diagnostic.t) -> (?init_loc:Span.t -> ?init_backtrace:Diagnostic.backtrace -> emit:('message Diagnostic.t -> unit) -> fatal:('message Diagnostic.t -> 'a) -> (unit -> 'a) -> 'a) -> (unit -> 'a) -> 'a
 
   (** [try_with ~emit ~fatal f] runs the thunk [f], using [emit] to intercept non-fatal diagnostics before continuing the computation (see {!val:emit} and {!val:emitf}), and [fatal] to intercept fatal diagnostics that have aborted the computation (see {!val:fatal} and {!val:fatalf}). The default interceptors re-emit or re-raise the intercepted diagnostics.
 
       @param emit The interceptor of non-fatal diagnostics. The default value is {!val:emit_diagnostic}.
       @param fatal The interceptor of fatal diagnostics. The default value is {!val:fatal_diagnostic}. *)
-  val try_with : ?emit:(Code.t Diagnostic.t -> unit) -> ?fatal:(Code.t Diagnostic.t -> 'a) -> (unit -> 'a) -> 'a
+  val try_with : ?emit:(Message.t Diagnostic.t -> unit) -> ?fatal:(Message.t Diagnostic.t -> 'a) -> (unit -> 'a) -> 'a
 
-  (** [map_diagnostic m f] runs the thunk [f] and applies [m] to any message sent by [f]. It is a convenience function that can be implemented as follows:
+  (** [map_diagnostic m f] runs the thunk [f] and applies [m] to any diagnostic sent by [f]. It is a convenience function that can be implemented as follows:
       {[
         let map_diagnostic m f =
           try_with
@@ -218,9 +218,9 @@ sig
 
       @since 0.2.0
   *)
-  val map_diagnostic : (Code.t Diagnostic.t -> Code.t Diagnostic.t) -> (unit -> 'a) -> 'a
+  val map_diagnostic : (Message.t Diagnostic.t -> Message.t Diagnostic.t) -> (unit -> 'a) -> 'a
 
-  (** [map_text m f] runs the thunk [f] and applies [m] to any message sent by [f]. It is a convenience function that can be implemented as follows:
+  (** [map_text m f] runs the thunk [f] and applies [m] to any text sent by [f]. It is a convenience function that can be implemented as follows:
       {[
         let map_text m f = map_diagnostic (Diagnostic.map_text m) f
       ]}
@@ -231,7 +231,7 @@ sig
 
   (** {2 Debugging} *)
 
-  val register_printer : ([ `Trace | `Emit of Code.t Diagnostic.t | `Fatal of Code.t Diagnostic.t ] -> string option) -> unit
+  val register_printer : ([ `Trace | `Emit of Message.t Diagnostic.t | `Fatal of Message.t Diagnostic.t ] -> string option) -> unit
   (** [register_printer p] registers a printer [p] via {!val:Printexc.register_printer} to convert unhandled internal effects and exceptions into strings for the OCaml runtime system to display. Ideally, all internal effects and exceptions should have been handled by {!val:run} and there is no need to use this function, but when it is not the case, this function can be helpful for debugging. The functor {!module:Reporter.Make} always registers a simple printer to suggest using {!val:run}, but you can register new ones to override it. The return type of the printer [p] should return [Some s] where [s] is the resulting string, or [None] if it chooses not to convert a particular effect or exception. The registered printers are tried in reverse order until one of them returns [Some s] for some [s]; that is, the last registered printer is tried first. Note that this function is a wrapper of {!val:Printexc.register_printer} and all the registered printers (via this function or {!val:Printexc.register_printer}) are put into the same list.
 
       The input type of the printer [p] is a variant representation of all internal effects and exceptions used in this module:
@@ -239,6 +239,6 @@ sig
       - [`Emit diag] corresponds to the effect triggered by {!val:emit}; and
       - [`Fatal diag] corresponds to the exception triggered by {!val:fatal}.
 
-      Note: {!val:Diagnostic.string_of_text} can be handy for converting a message into a string.
+      Note: {!val:Diagnostic.string_of_text} can be handy for converting a text into a string.
   *)
 end

--- a/src/lsp/AsaiLsp.ml
+++ b/src/lsp/AsaiLsp.ml
@@ -1,9 +1,9 @@
 module L = Lsp.Types
 module RPC = Jsonrpc
 
-module Make (Code : Reporter.Code) =
+module Make (Message : Reporter.Message) =
 struct
-  module Server = LspServer.Make(Code)
+  module Server = LspServer.Make(Message)
   open Server
 
   let unwrap opt err =

--- a/src/lsp/AsaiLsp.mli
+++ b/src/lsp/AsaiLsp.mli
@@ -11,10 +11,10 @@
     Note: many features are missing and it does not handle [positionEncoding].
 
     @canonical Asai.Lsp.Make *)
-module Make (Code : Reporter.Code) : sig
+module Make (Message : Reporter.Message) : sig
   val start : source:string option
     -> init:(root:string option -> unit)
-    -> load_file:(display:(Code.t Diagnostic.t -> unit) -> string -> unit)
+    -> load_file:(display:(Message.t Diagnostic.t -> unit) -> string -> unit)
     -> unit
     (** [run ~init ~load_file] starts the LSP server with the two callbacks [init] and [load_file].
 

--- a/src/lsp/LspServer.mli
+++ b/src/lsp/LspServer.mli
@@ -1,7 +1,7 @@
 module L := Lsp.Types
 module RPC := Jsonrpc
 
-module Make (Code : Reporter.Code) : sig
+module Make (Message : Reporter.Message) : sig
   type lsp_error =
     | DecodeError of string
     | HandshakeError of string
@@ -39,7 +39,7 @@ module Make (Code : Reporter.Code) : sig
   val run : Eio_unix.Stdenv.base
     -> ?source:string
     -> init:(root:string option -> unit)
-    -> load_file:(display:(Code.t Diagnostic.t -> unit) -> string -> unit)
+    -> load_file:(display:(Message.t Diagnostic.t -> unit) -> string -> unit)
     -> (unit -> 'a)
     -> 'a
 end

--- a/src/tty/Tty.mli
+++ b/src/tty/Tty.mli
@@ -5,7 +5,7 @@
 (** {1 Display} *)
 
 (** This module provides functions to display or interact with diagnostics in UNIX terminals. *)
-module Make (Code : Reporter.Code) : sig
+module Make (Message : Reporter.Message) : sig
 
   (** [display d] prints the diagnostic [d] to the standard output, using terminal control characters for formatting. A message will look like this:
 
@@ -39,7 +39,7 @@ module Make (Code : Reporter.Code) : sig
 
       @raise Invalid_argument if [tab_size < 0].
   *)
-  val display : ?output:out_channel -> ?show_backtrace:bool -> ?line_breaking:[`Unicode | `Traditional] -> ?block_splitting_threshold:int -> ?tab_size:int -> Code.t Diagnostic.t -> unit
+  val display : ?output:out_channel -> ?show_backtrace:bool -> ?line_breaking:[`Unicode | `Traditional] -> ?block_splitting_threshold:int -> ?tab_size:int -> Message.t Diagnostic.t -> unit
 
   (** [interactive_trace d] drops the user in a small interactive terminal app where they can cycle through the message provided in [d] and its backtrace.
 
@@ -51,5 +51,5 @@ module Make (Code : Reporter.Code) : sig
 
       @raise Invalid_argument if [tab_size < 0].
   *)
-  val interactive_trace : ?input:Unix.file_descr -> ?output:Unix.file_descr -> ?line_breaking:[`Unicode | `Traditional] -> ?block_splitting_threshold:int -> ?tab_size:int -> Code.t Diagnostic.t -> unit
+  val interactive_trace : ?input:Unix.file_descr -> ?output:Unix.file_descr -> ?line_breaking:[`Unicode | `Traditional] -> ?block_splitting_threshold:int -> ?tab_size:int -> Message.t Diagnostic.t -> unit
 end


### PR DESCRIPTION
| | now | this PR | notes
| - | - | - | - |
| type of texts | `text` | `text` _(unchanged)_  | |
| type of texts with location information | `message` | `loctext` | portmanteau |
| the field in diagnostics for free-form texts | `message` | `explanation` | of type `loctext` |
| the field in diagnostics for additional notes | `additional_messages` | `extra_remarks` | |
| parameter module name | `Reporter.Code` | `Reporter.Message` |  |
| conversion to short Google-able strings | `Code.to_string` | `Message.short_code` |  |

This is in for eventually completing #97.