### PR TITLE
feat: allow titles for string sources

### DIFF
--- a/src/SourceReader.ml
+++ b/src/SourceReader.ml
@@ -33,7 +33,7 @@ type source = File of bigstring | String of string
 let load : Span.source -> _ =
   function
   | `File file_path -> File (snd @@ FileInternal.load file_path)
-  | `String str -> String str
+  | `String {content; _} -> String content
 
 let length =
   function

--- a/src/Span.ml
+++ b/src/Span.ml
@@ -1,4 +1,9 @@
-type source = [`File of string | `String of string]
+type string_source = {
+  title: string option;
+  content: string;
+}
+
+type source = [`File of string | `String of string_source]
 
 type position = {
   source : source;
@@ -11,10 +16,23 @@ type t = position * position
 
 type 'a located = { loc : t option; value : 'a }
 
+let dump_string fmt s = Format.fprintf fmt "%S" s [@@inline]
+
+let dump_option dump fmt =
+  function
+  | None -> Format.pp_print_string fmt "None"
+  | Some v -> Format.fprintf fmt "Some %a" dump v
+
+let dump_string_source fmt {title; content} =
+  Format.fprintf fmt "@[{title=%a;@ content=%a}@]"
+    (dump_option dump_string) title dump_string content
+
 let dump_source fmt : source -> unit =
   function
-  | `File s -> Format.fprintf fmt "(`File %S)" s
-  | `String s -> Format.fprintf fmt "(`String %S)" s
+  | `File s -> Format.fprintf fmt "(`File %a)" dump_string s
+  | `String str_src ->
+    Format.fprintf fmt "@[<3>(`String@ @[%a@])@]"
+      dump_string_source str_src
 
 let make (begin_ , end_ : position * position) : t =
   if begin_.source <> end_.source then

--- a/src/Span.mli
+++ b/src/Span.mli
@@ -1,9 +1,18 @@
 (** {1 Types} *)
 
+(** The string source of a position or a span. *)
+type string_source = {
+  title: string option;
+  (** The title of a string source, which can be [Some "<stdio>"]. *)
+
+  content: string;
+  (** The content of a string source *)
+}
+
 (** The source of a position or a span. The [`String] source can be used for REPL. *)
 type source =
   [ `File of string (** File path of the source file. *)
-  | `String of string (** The content of an in-memory source. *)
+  | `String of string_source (** The content of an in-memory source. *)
   ]
 
 (** The type of positions; this is isomorphic to {!type:Lexing.position}, but with arguably better field names. *)

--- a/src/tty/Tty.ml
+++ b/src/tty/Tty.ml
@@ -186,18 +186,18 @@ struct
 
   (* [ ╒══ examples/stlc/source.lambda] *)
   (* [ │ ] *)
-  let render_source_header ~param =
+  let render_source_header ~param : Span.source -> I.t =
     function
-    | `String _ ->
+    | `String {title=None; _} ->
       hcat_with_pad ~pad:1
         [ I.void param.line_number_width 0
         ; I.string fringe_style "┯"
         ]
-    | `File file_path ->
+    | `File title | `String {title=Some title; _} ->
       hcat_with_pad ~pad:1
         [ I.void param.line_number_width 0
         ; I.string fringe_style "╒══" <-> I.string fringe_style "│"
-        ; I.string A.empty file_path
+        ; I.string A.empty title
         ]
 
   let show_code_segment ~param Explication.{style; value = seg} =

--- a/test/TestExplicator.ml
+++ b/test/TestExplicator.ml
@@ -17,7 +17,7 @@ module E = Explicator.Make(IntStyle)
 let test_explication = Alcotest.of_pp (Explication.dump IntStyle.dump)
 
 let single_line mode eol () =
-  let source = `String ("aaabbbcccdddeee" ^ eol) in
+  let source = `String {Span.title = None; content = "aaabbbcccdddeee" ^ eol} in
   let start_of_line1 : Span.position = {source; offset = 0; start_of_line = 0; line_num = 1} in
   let span1 = Explication.style 1 @@ Span.make ({start_of_line1 with offset = 3}, {start_of_line1 with offset = 9}) in
   let span2 = Explication.style 2 @@ Span.make ({start_of_line1 with offset = 6}, {start_of_line1 with offset = 12}) in
@@ -38,7 +38,7 @@ let single_line mode eol () =
   Alcotest.(check test_explication) "Explication is correct" expected actual
 
 let multi_lines_with_ls () =
-  let source = `String "aabbbbb\u{2028}bbbbccc" in
+  let source = `String {Span.title = None; content = "aabbbbb\u{2028}bbbbccc"} in
   let start_of_line1 : Span.position = {source; offset = 0; start_of_line = 0; line_num = 1} in
   let start_of_line2 : Span.position = {source; offset = 10; start_of_line = 10; line_num = 2} in
   let span = Explication.style 1 @@ Span.make ({start_of_line1 with offset = 2}, {start_of_line2 with offset = 14}) in
@@ -60,8 +60,11 @@ let multi_lines_with_ls () =
   Alcotest.(check test_explication) "Explication is correct" expected actual
 
 let multi_lines () =
-  let source = `String
-      {|
+  let source =
+    `String
+      {Span.title = None;
+       content =
+         {|
 aabbbbb
 bbbbbbb
 b*ccddd
@@ -76,7 +79,7 @@ ee++fff
 4
 5
 ggggghh
-|}
+|}}
   in
   let start_of_line2 : Span.position = {source; offset = 1; start_of_line = 1; line_num = 2} in
   let start_of_line4 : Span.position = {source; offset = 17; start_of_line = 17; line_num = 4} in


### PR DESCRIPTION
Previously, for string sources, no file paths can be shown. This PR makes it possible to assign a title to a string source.

Close #99.