### PR TITLE
feat(LibSigs): help library authors hide internal reporters

### DIFF
--- a/docs/quickstart.mld
+++ b/docs/quickstart.mld
@@ -167,7 +167,7 @@ struct
   let default_severity : t -> Asai.Diagnostic.severity =
     function
     (* ... *)
-    | Cool c -> CoolLibrary.Reporter.default_severity c
+    | Cool _ -> assert false (* You probably should not create new diagnostics using the cool library's messages. *)
 
   (** A short, concise, ideally Google-able string representation for each message. *)
   let short_code : t -> string =

--- a/examples/adopt/lib/Syslib.mli
+++ b/examples/adopt/lib/Syslib.mli
@@ -1,0 +1,2 @@
+module Reporter : Asai.LibSigs.Reporter
+module Operations = Operations

--- a/src/Asai.ml
+++ b/src/Asai.ml
@@ -2,6 +2,7 @@ module Range = Range
 module Diagnostic = Diagnostic
 module Reporter = Reporter
 module StructuredReporter = StructuredReporter
+module LibSigs = LibSigs
 
 module Tty = Tty
 module GitHub = GitHub

--- a/src/Asai.mli
+++ b/src/Asai.mli
@@ -20,6 +20,11 @@ module Reporter = Reporter
     @since 0.2.0 *)
 module StructuredReporter = StructuredReporter
 
+(** Signatures that help a library author expose a minimum interface of their internal reporter.
+
+    @since 0.3.0 *)
+module LibSigs = LibSigs
+
 (** {1 Experimental Diagnostic Handlers} *)
 
 (** These handlers are subject to changes, but we will minimize incompatible changes between minor versions. *)

--- a/src/LibSigs.ml
+++ b/src/LibSigs.ml
@@ -1,24 +1,22 @@
 module type Reporter =
 sig
+  (** This is a template signature provided by asai. The author of the library you are using employs this template to hide almost everything from the public interface except the minimum API for you to adopt it. In the following documentation, "the library" refers to the library using this template, not asai. *)
+
   module Message :
   sig
     (** The type of all messages from the library you use. *)
     type t
 
-    (** The default severity level of a message from the library you use. *)
-    val default_severity : t -> Diagnostic.severity
-
-    (** A concise, ideally Google-able string representation of each message from this library. *)
+    (** A concise, ideally Google-able string representation of each message from the library. *)
     val short_code : t -> string
   end
 
-  (** [run ~emit ~fatal f] runs the thunk [f], using [emit] to handle non-fatal diagnostics before continuing the computation (see {!val:emit} and {!val:emitf}), and [fatal] to handle fatal diagnostics that have aborted the computation (see {!val:fatal} and {!val:fatalf}).
-
-      The recommended way to embed messages from a library using asai is to use {!val:Reporter.S.adopt}:
+  (** [run ~emit ~fatal f] runs the thunk [f], using [emit] to handle non-fatal diagnostics from the library before continuing the computation, and [fatal] to handle fatal diagnostics from the library that have aborted the computation. The recommended way to handle messages from the library is to use {!val:Asai.Reporter.S.adopt}:
       {[
-        let _ = Reporter.adopt (Diagnostic.map message_mapper) ThisLib.Reporter.run @@ fun () -> ...
+        Reporter.adopt (Diagnostic.map message_mapper) The_library.Reporter.run @@ fun () -> ...
       ]}
 
+      @param init_loc The initial default location for inner {!val:emit} and {!val:fatal}. The default value is [None].
       @param init_backtrace The initial backtrace to start with. The default value is the empty backtrace.
       @param emit The handler of non-fatal diagnostics.
       @param fatal The handler of fatal diagnostics. *)

--- a/src/LibSigs.ml
+++ b/src/LibSigs.ml
@@ -1,0 +1,26 @@
+module type Reporter =
+sig
+  module Message :
+  sig
+    (** The type of all messages from the library you use. *)
+    type t
+
+    (** The default severity level of a message from the library you use. *)
+    val default_severity : t -> Diagnostic.severity
+
+    (** A concise, ideally Google-able string representation of each message from this library. *)
+    val short_code : t -> string
+  end
+
+  (** [run ~emit ~fatal f] runs the thunk [f], using [emit] to handle non-fatal diagnostics before continuing the computation (see {!val:emit} and {!val:emitf}), and [fatal] to handle fatal diagnostics that have aborted the computation (see {!val:fatal} and {!val:fatalf}).
+
+      The recommended way to embed messages from a library using asai is to use {!val:Reporter.S.adopt}:
+      {[
+        let _ = Reporter.adopt (Diagnostic.map message_mapper) ThisLib.Reporter.run @@ fun () -> ...
+      ]}
+
+      @param init_backtrace The initial backtrace to start with. The default value is the empty backtrace.
+      @param emit The handler of non-fatal diagnostics.
+      @param fatal The handler of fatal diagnostics. *)
+  val run : ?init_loc:Range.t -> ?init_backtrace:Diagnostic.backtrace -> emit:(Message.t Diagnostic.t -> unit) -> fatal:(Message.t Diagnostic.t -> 'a) -> (unit -> 'a) -> 'a
+end

--- a/src/ReporterSigs.ml
+++ b/src/ReporterSigs.ml
@@ -193,11 +193,9 @@ sig
             f
       ]}
 
-      Here shows the intended usage, where [Lib] is the library to be used in the main application:
+      Here shows the intended usage, where [Cool_lib] is the library to be used in the main application:
       {[
-        module LibReporter = Lib.Reporter
-
-        let _ = Reporter.adopt (Diagnostic.map message_mapper) LibReporter.run @@ fun () -> ...
+        let _ = Reporter.adopt (Diagnostic.map message_mapper) Cool_lib.Reporter.run @@ fun () -> ...
       ]}
   *)
   val adopt : ('message Diagnostic.t -> Message.t Diagnostic.t) -> (?init_loc:Range.t -> ?init_backtrace:Diagnostic.backtrace -> emit:('message Diagnostic.t -> unit) -> fatal:('message Diagnostic.t -> 'a) -> (unit -> 'a) -> 'a) -> (unit -> 'a) -> 'a

--- a/src/ReporterSigs.ml
+++ b/src/ReporterSigs.ml
@@ -174,8 +174,8 @@ sig
 
   (** [run ~emit ~fatal f] runs the thunk [f], using [emit] to handle non-fatal diagnostics before continuing the computation (see {!val:emit}), and [fatal] to handle fatal diagnostics that have aborted the computation (see {!val:fatal}).
 
-      @param init_loc The initial default location for inner {!val:emit} and {!val:fatal}. The default value is [None].
-      @param init_backtrace The initial backtrace to start with. The default value is the empty backtrace.
+      @param init_loc The initial default location for internal {!val:emit} and {!val:fatal} within the library. The default value is [None].
+      @param init_backtrace The initial backtrace for the library to start with. The default value is the empty backtrace.
       @param emit The handler of non-fatal diagnostics.
       @param fatal The handler of fatal diagnostics. *)
   val run : ?init_loc:Range.t -> ?init_backtrace:Diagnostic.backtrace -> emit:(Message.t Diagnostic.t -> unit) -> fatal:(Message.t Diagnostic.t -> 'a) -> (unit -> 'a) -> 'a
@@ -195,7 +195,7 @@ sig
 
       Here shows the intended usage, where [Cool_lib] is the library to be used in the main application:
       {[
-        let _ = Reporter.adopt (Diagnostic.map message_mapper) Cool_lib.Reporter.run @@ fun () -> ...
+        Reporter.adopt (Diagnostic.map message_mapper) Cool_lib.Reporter.run @@ fun () -> ...
       ]}
   *)
   val adopt : ('message Diagnostic.t -> Message.t Diagnostic.t) -> (?init_loc:Range.t -> ?init_backtrace:Diagnostic.backtrace -> emit:('message Diagnostic.t -> unit) -> fatal:('message Diagnostic.t -> 'a) -> (unit -> 'a) -> 'a) -> (unit -> 'a) -> 'a

--- a/src/StructuredReporterSigs.ml
+++ b/src/StructuredReporterSigs.ml
@@ -145,11 +145,9 @@ sig
             f
       ]}
 
-      Here shows the intended usage, where [Lib] is the library to be used in the main application:
+      Here shows the intended usage, where [Cool_lib] is the library to be used in the main application:
       {[
-        module LibReporter = Lib.Reporter
-
-        let _ = Reporter.adopt (Diagnostic.map message_mapper) LibReporter.run @@ fun () -> ...
+        let _ = Reporter.adopt (Diagnostic.map message_mapper) Cool_lib.Reporter.run @@ fun () -> ...
       ]}
   *)
   val adopt : ('message Diagnostic.t -> Message.t Diagnostic.t) -> (?init_loc:Range.t -> ?init_backtrace:Diagnostic.backtrace -> emit:('message Diagnostic.t -> unit) -> fatal:('message Diagnostic.t -> 'a) -> (unit -> 'a) -> 'a) -> (unit -> 'a) -> 'a

--- a/src/StructuredReporterSigs.ml
+++ b/src/StructuredReporterSigs.ml
@@ -147,7 +147,7 @@ sig
 
       Here shows the intended usage, where [Cool_lib] is the library to be used in the main application:
       {[
-        let _ = Reporter.adopt (Diagnostic.map message_mapper) Cool_lib.Reporter.run @@ fun () -> ...
+        Reporter.adopt (Diagnostic.map message_mapper) Cool_lib.Reporter.run @@ fun () -> ...
       ]}
   *)
   val adopt : ('message Diagnostic.t -> Message.t Diagnostic.t) -> (?init_loc:Range.t -> ?init_backtrace:Diagnostic.backtrace -> emit:('message Diagnostic.t -> unit) -> fatal:('message Diagnostic.t -> 'a) -> (unit -> 'a) -> 'a) -> (unit -> 'a) -> 'a


### PR DESCRIPTION
As a library author using asai, I don't want to expose the entire internal reporter to the library user. This PR should make the wrapping trivial for a library author to adopt asai. The idiom is for the library writer to protect their internal Reporter with this:
```ocaml
module Reporter : Asai.LibSigs.Reporter
```