### PR TITLE
fix(Diagnostic): use Format.pp_infinity in string_of_text for OCaml 5.2

### DIFF
--- a/.github/workflows/ocaml.yaml
+++ b/.github/workflows/ocaml.yaml
@@ -10,6 +10,7 @@ jobs:
       matrix:
         include:
           - ocaml-compiler: "ocaml-base-compiler.5.0.0"
+          - ocaml-compiler: "ocaml-base-compiler.5.2.0~alpah1"
           - ocaml-compiler: "ocaml-base-compiler.5.1.1"
             with-doc: true
     runs-on: ubuntu-latest

--- a/.github/workflows/ocaml.yaml
+++ b/.github/workflows/ocaml.yaml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         include:
           - ocaml-compiler: "ocaml-base-compiler.5.2.0~alpha1"
-            with-doc: true
+            with-doc: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ocaml.yaml
+++ b/.github/workflows/ocaml.yaml
@@ -9,9 +9,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - ocaml-compiler: "ocaml-base-compiler.5.0.0"
           - ocaml-compiler: "ocaml-base-compiler.5.2.0~alpah1"
-          - ocaml-compiler: "ocaml-base-compiler.5.1.1"
             with-doc: true
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ocaml.yaml
+++ b/.github/workflows/ocaml.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - ocaml-compiler: "ocaml-base-compiler.5.2.0~alpah1"
+          - ocaml-compiler: "ocaml-base-compiler.5.2.0~alpha1"
             with-doc: true
     runs-on: ubuntu-latest
     steps:

--- a/asai-examples.opam
+++ b/asai-examples.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/RedPRL/asai"
 bug-reports: "https://github.com/RedPRL/asai/issues"
 depends: [
   "dune" {>= "3.1"}
-  "ocaml" {>= "5.0"}
+  "ocaml" {>= "5.2"}
   "algaeff" {>= "2.0"}
   "bwd" {>= "2.2"}
   "menhir" {>= "20220210"}

--- a/asai-lsp.opam
+++ b/asai-lsp.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/RedPRL/asai"
 bug-reports: "https://github.com/RedPRL/asai/issues"
 depends: [
   "dune" {>= "3.1"}
-  "ocaml" {>= "5.0"}
+  "ocaml" {>= "5.2"}
   "bwd" {>= "2.2"}
   "eio" {>= "0.12"}
   "eio_main" {>= "0.12"}

--- a/asai.opam
+++ b/asai.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/RedPRL/asai"
 bug-reports: "https://github.com/RedPRL/asai/issues"
 depends: [
   "dune" {>= "3.1"}
-  "ocaml" {>= "5.0"}
+  "ocaml" {>= "5.2"}
   "algaeff" {>= "2.0"}
   "bwd" {>= "2.2"}
   "alcotest" {with-test & >= "1.5"}

--- a/dune-project
+++ b/dune-project
@@ -17,7 +17,7 @@
  (synopsis "A library for constructing and printing compiler diagnostics")
  (description "This package offers an implementation of compiler diagnostics and supports multiple handlers for displaying diagnostics to the end user. Currently, the package comes with built-in handlers for GitHub Actions workflow commands and UNIX terminals.")
  (depends
-   (ocaml (>= 5.0))
+   (ocaml (>= 5.2))
    (algaeff (>= 2.0))
    (bwd (>= 2.2))
    (alcotest (and :with-test (>= 1.5)))
@@ -27,7 +27,7 @@
  (synopsis "LSP handler for the package asai")
  (description "This package offers an language server protocol (LSP) handler that can turn an application using the asai package into a LSP server. This is an experimental prototype and very likely its design will significantly change in future versions.")
  (depends
-   (ocaml (>= 5.0))
+   (ocaml (>= 5.2))
    (bwd (>= 2.2))
    (eio (>= 0.12))
    (eio_main (>= 0.12))
@@ -39,7 +39,7 @@
  (synopsis "Examples of the package asai")
  (description "This package offers some examples of the asai package. They are organized into a separate package to reduce the dependencies of the main package.")
  (depends
-   (ocaml (>= 5.0))
+   (ocaml (>= 5.2))
    (algaeff (>= 2.0))
    (bwd (>= 2.2))
    (menhir (>= 20220210))

--- a/src/Diagnostic.ml
+++ b/src/Diagnostic.ml
@@ -42,8 +42,7 @@ let map f d = {d with message = f d.message}
 let string_of_text text : string =
   let buf = Buffer.create 20 in
   let fmt = Format.formatter_of_buffer buf in
-  (* TODO: Use ~margin:Format.pp_infinity when this code requires OCaml 5.2 *)
-  let () = Format.pp_set_geometry fmt ~max_indent:2 ~margin:1_000_000_000 in
+  let () = Format.pp_set_geometry fmt ~max_indent:2 ~margin:Format.pp_infinity in
   text fmt;
   Format.pp_print_flush fmt ();
   Str.global_replace (Str.regexp "\\([\r\n]+ *\\)+") " " @@

--- a/src/Diagnostic.ml
+++ b/src/Diagnostic.ml
@@ -42,7 +42,8 @@ let map f d = {d with message = f d.message}
 let string_of_text text : string =
   let buf = Buffer.create 20 in
   let fmt = Format.formatter_of_buffer buf in
-  let () = Format.pp_set_geometry fmt ~max_indent:2 ~margin:Int.max_int in
+  (* TODO: Use ~margin:Format.pp_infinity when this code requires OCaml 5.2 *)
+  let () = Format.pp_set_geometry fmt ~max_indent:2 ~margin:1_000_000_000 in
   text fmt;
   Format.pp_print_flush fmt ();
   Str.global_replace (Str.regexp "\\([\r\n]+ *\\)+") " " @@

--- a/src/Diagnostic.ml
+++ b/src/Diagnostic.ml
@@ -42,7 +42,7 @@ let map f d = {d with message = f d.message}
 let string_of_text text : string =
   let buf = Buffer.create 20 in
   let fmt = Format.formatter_of_buffer buf in
-  let () = Format.pp_set_geometry fmt ~max_indent:2 ~margin:Format.pp_infinity in
+  let () = Format.pp_set_geometry fmt ~max_indent:2 ~margin:(Format.pp_infinity-1) in
   text fmt;
   Format.pp_print_flush fmt ();
   Str.global_replace (Str.regexp "\\([\r\n]+ *\\)+") " " @@

--- a/src/Explicator.ml
+++ b/src/Explicator.ml
@@ -83,7 +83,7 @@ module Make (Tag : Tag) = struct
       let source = SourceReader.load ploc.source in
       let eof = SourceReader.length source in
       let find_eol i = UserContent.find_eol ~line_breaks (SourceReader.unsafe_get source) (i, eof) in
-      let[@tailcall] rec go state : (Tag.t option * Range.position) list -> _ =
+      let rec go state : (Tag.t option * Range.position) list -> _ =
         function
         | (ptag, ploc) :: ps when state.cursor.line_num = ploc.line_num ->
           if ploc.offset > eof then invalid_arg "Asai.Explicator.explicate: beyond eof; use the debug mode";


### PR DESCRIPTION
See https://github.com/ocaml/ocaml/discussions/12986
Otherwise the code fails with:
```
#=== ERROR while compiling asai.0.3.0 =========================================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/asai.0.3.0
# command              ~/.opam/5.2/bin/dune build -p asai -j 1 @install @runtest
# exit-code            1
# env-file             ~/.opam/log/asai-62-9d2d7d.env
# output-file          ~/.opam/log/asai-62-9d2d7d.out
### output ###
# (cd _build/default/test && ./TestUserContent.exe)
# Testing `UserContent'.
# This run has ID `9FIAG1G5'.
# 
#   [OK]          replace_control          0   tab.
#   [OK]          replace_control          1   C1 control.
#   [OK]          replace_control          2   C2 control.
#   [OK]          replace_control          3   invalid UTF-8.
#   [OK]          replace_control          4   invalid UTF-8.
# 
# Full test results in `~/.opam/5.2/.opam-switch/build/asai.0.3.0/_build/default/test/_build/_tests/UserContent'.
# Test Successful in 0.000s. 5 tests run.
# File "test/dune", line 7, characters 24-38:
# 7 |  (names TestUserContent TestDiagnostic)
#                             ^^^^^^^^^^^^^^
# (cd _build/default/test && ./TestDiagnostic.exe)
# Testing `UserContent'.
# This run has ID `P63ACD2O'.
# 
# > [FAIL]        string_of_text          0   \n.
# 
# ┌──────────────────────────────────────────────────────────────────────────────┐
# │ [FAIL]        string_of_text          0   \n.                                │
# └──────────────────────────────────────────────────────────────────────────────┘
# [invalid] Format.pp_set_geometry: margin >= pp_infinity
#           Raised at Stdlib__Format.pp_set_geometry in file "format.ml", line 844, characters 4-63
#           Called from Asai__Diagnostic.string_of_text in file "src/Diagnostic.ml", line 45, characters 11-71
#           Called from Dune__exe__TestDiagnostic.of_test.(fun) in file "test/TestDiagnostic.ml", line 4, characters 2-38
#           Called from Alcotest_engine__Core.Make.protect_test.(fun) in file "src/alcotest-engine/core.ml", line 181, characters 17-23
#           Called from Alcotest_engine__Monad.Identity.catch in file "src/alcotest-engine/monad.ml", line 24, characters 31-35
#           
# Logs saved to `~/.opam/5.2/.opam-switch/build/asai.0.3.0/_build/default/test/_build/_tests/UserContent/string_of_text.000.output'.
#  ──────────────────────────────────────────────────────────────────────────────
# 
# Full test results in `~/.opam/5.2/.opam-switch/build/asai.0.3.0/_build/default/test/_build/_tests/UserContent'.
# 1 failure! in 0.000s. 1 test run.
# (cd _build/default/test && ./TestExplicator.exe)
# Testing `Explicator'.
# This run has ID `VS14DHRF'.
# 
#   [OK]          single-line          0   traditional, empty.
#   [OK]          single-line          1   traditional, CR.
#   [OK]          single-line          2   traditional, LF.
#   [OK]          single-line          3   traditional, CRLF.
#   [OK]          single-line          4   unicode, empty.
#   [OK]          single-line          5   unicode, CR.
#   [OK]          single-line          6   unicode, LF.
#   [OK]          single-line          7   unicode, CRLF.
#   [OK]          single-line          8   unicode, VT.
#   [OK]          single-line          9   unicode, FF.
#   [OK]          single-line         10   unicode, NEL.
#   [OK]          single-line         11   unicode, LS.
#   [OK]          single-line         12   unicode, PS.
#   [OK]          multi-line           0   multi-line range with LS.
#   [OK]          multi-line           1   multi-line range with CRLF.
# 
# Full test results in `~/.opam/5.2/.opam-switch/build/asai.0.3.0/_build/default/test/_build/_tests/Explicator'.
# Test Successful in 0.001s. 15 tests run.
# (cd _build/default/test && ./TestFlattener.exe)
# Testing `Flattener'.
# This run has ID `ZU125I9G'.
# 
#   [OK]          flattening          0   single-line ranges.
#   [OK]          flattening          1   multi-line ranges.
# 
# Full test results in `~/.opam/5.2/.opam-switch/build/asai.0.3.0/_build/default/test/_build/_tests/Flattener'.
# Test Successful in 0.000s. 2 tests run.
```