### PR TITLE
fix(lsp): breaking changes from lsp 1.19.0

### DIFF
--- a/src-lsp/LspServer.ml
+++ b/src-lsp/LspServer.ml
@@ -74,7 +74,7 @@ struct
       ~severity
       ~code
       ?source
-      ~message
+      ~message:(`String message)
       ~relatedInformation
       ()
 


### PR DESCRIPTION
The upstream introduced breaking changes in https://github.com/ocaml/ocaml-lsp/pull/1332 (released at 1.19.0).